### PR TITLE
Maybe improve the stats and histograms at the end of a run?

### DIFF
--- a/qcat/cli.py
+++ b/qcat/cli.py
@@ -400,9 +400,14 @@ def print_barcode_hist(barcode_dist, adapter_dist, total_reads):
             barcodes_detected += value
     logging.info("Barcodes detected in %d of %d adapters" % (barcodes_detected, adapters_detected))
     for bcid in sorted(barcode_dist):
-        perc = barcode_dist[bcid] * 100.0 / total_reads
-        logging.info("%15s %6d: | %20s | %6s %%" % (bcid, barcode_dist[bcid],
-                                    int(perc / 5) * "#", "{:.2f}".format(perc)))
+        perc = barcode_dist[bcid] * 100.0 / adapters_detected
+        total_perc = barcode_dist[bcid] * 100.0 / total_reads
+        logging.info("%15s %6d: | %20s | %6s %% (%s%% of all reads)" % (
+                         bcid,
+                         barcode_dist[bcid],
+                         int(perc / 5) * "#",
+                         "{:.2f}".format(perc),
+                         "{:.2f}".format(total_perc)))
 
 
 def write_multiplexing_result(barcode_dict, comment, name, sequence, tsv):

--- a/qcat/cli.py
+++ b/qcat/cli.py
@@ -398,7 +398,7 @@ def print_barcode_hist(barcode_dist, adapter_dist, total_reads):
     for key, value in six.iteritems(barcode_dist):
         if key != "none":
             barcodes_detected += value
-    logging.info("Barcodes detected in %d of %d adapters" % (barcodes_detected, total_reads))
+    logging.info("Barcodes detected in %d of %d adapters" % (barcodes_detected, adapters_detected))
     for bcid in sorted(barcode_dist):
         perc = barcode_dist[bcid] * 100.0 / total_reads
         logging.info("%15s %6d: | %20s | %6s %%" % (bcid, barcode_dist[bcid],

--- a/qcat/cli.py
+++ b/qcat/cli.py
@@ -530,8 +530,9 @@ def qcat_cli(reads_fq, kit, mode, nobatch, out,
                 continue
 
             # Record which adapter/barcode was found
-            barcode_found(barcode_dist, result['barcode'])
             adapter_found(adapter_dist, result['adapter'])
+            if result['adapter']:
+                barcode_found(barcode_dist, result['barcode'])
 
             # Write tsv result file
             write_multiplexing_result(result,


### PR DESCRIPTION
Example output before:

```
Adapters detected in 253 of 4000 reads
          mykit    253: |                    # |   6.33 %
           none   3747: |   ################## |  93.67 %
Barcodes detected in 253 of 4000 adapters
       barcode1     13: |                      |   0.33 %
       barcode2      8: |                      |   0.20 %
       barcode3     35: |                      |   0.88 %
       barcode4    163: |                      |   4.08 %
       barcode5     34: |                      |   0.85 %
           none   3747: |   ################## |  93.67 %
Demultiplexing finished in 1.89s
```

Example output after

```
Adapters detected in 253 of 4000 reads
          mykit    253: |                    # |   6.33 %
           none   3747: |   ################## |  93.67 %
Barcodes detected in 253 of 253 adapters
       barcode1     13: |                    # |   5.14 % (0.33% of all reads)
       barcode2      8: |                      |   3.16 % (0.20% of all reads)
       barcode3     35: |                   ## |  13.83 % (0.88% of all reads)
       barcode4    163: |         ############ |  64.43 % (4.08% of all reads)
       barcode5     34: |                   ## |  13.44 % (0.85% of all reads)
Demultiplexing finished in 1.90s
```

Now that I'm finished, I'm not sure whether this is truly an improvement. The "253 of 4000 adapters" text was weird before (why "of 4000 adapters" if only 253 were found?), but perhaps the old barcode histogram with a `none` row was actually more useful? Perhaps the better change would've been a much smaller one: just changing the word "adapters" to "reads" (so that the message would say "Barcodes detected in 253 of 4000 reads") and otherwise leave everything as it was.

I'll leave it for the maintainers to consider!